### PR TITLE
Use correct span for binary entries

### DIFF
--- a/src/nvs_partition.rs
+++ b/src/nvs_partition.rs
@@ -631,7 +631,7 @@ impl<const NUMBER_OF_ENTRIES: usize> NvsPartition<NUMBER_OF_ENTRIES> {
             let bytes_remaining = value_len - bytes_written;
             let chunk_size = usize::min((num_remaining_entries - 1) * Entry::SIZE, bytes_remaining);
             let mut chunk_data = &value[bytes_written..bytes_written + chunk_size];
-            let span = chunk_size.div_ceil(Entry::SIZE);
+            let span = chunk_size.div_ceil(Entry::SIZE) + 1;
             assert!(span >= 1);
             assert!(span < NUMBER_OF_ENTRIES);
             let entry =


### PR DESCRIPTION
The library generated an invalid NVS partition for binary data. To fix this, I simply needed to increase the "span" of the binary data by one, as it seems to include the blob index as well (for instance, 256 bytes of data do not have a span of 8, they have a span of 9). The output of this library and the ESP-IDF NVS partition generator is now the same.